### PR TITLE
Add threshold parameter and change the default to 0.050

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ python point_slice_studio_cli.py [input_directory] [output_file] [options]
   - Default: `-40.0`
 - `--label-y FLOAT`: Y position for label start
   - Default: `0.0`
+  
+- `--threshold FLOAT`: Slice detection threshold (max allowed variation of the smallest axis)
+  - Default: `0.050` (smaller is stricter; larger is more tolerant)
 
 ### Features
 
@@ -208,6 +211,9 @@ python point_slice_studio_cli.py --colors 1 3 5 4
 
 # Position labels at custom location
 python point_slice_studio_cli.py --label-x -100 --label-y 50
+
+# Adjust slice detection threshold (e.g., stricter)
+python point_slice_studio_cli.py path/to/csv/files output.dxf --threshold 0.005
 ```
 
 ### Output

--- a/point_slice_studio_cli.py
+++ b/point_slice_studio_cli.py
@@ -46,10 +46,11 @@ from points_slice import SliceType, rotate_slice_to_xy  # noqa: E402
 
 
 def create_dxf_from_csv_directory(
-    input_directory: str, 
+    input_directory: str,
     output_file: str,
     colors: List[int] = None,
-    label_position: tuple[float, float] = None
+    label_position: tuple[float, float] = None,
+    threshold: float = 0.050,
 ) -> None:
     """
     Create a DXF file from CSV files in a directory.
@@ -80,7 +81,7 @@ def create_dxf_from_csv_directory(
     print(f"📂 Parsing CSV files from: {input_directory}")
     parsing_start_time = time.perf_counter()
     try:
-        points_slices = parse_directory(input_directory)
+        points_slices = parse_directory(input_directory, threshold=threshold)
     except Exception as e:
         print(f"❌ Error parsing CSV files: {e}")
         return
@@ -110,6 +111,7 @@ def create_dxf_from_csv_directory(
 
         # Rotate XZ and YZ slices to XY plane
         if points_slice.slice_type == SliceType.XZ or points_slice.slice_type == SliceType.YZ:
+            # Create rotated slice block
             points_slice_rotated = rotate_slice_to_xy(points_slice)
             block_name_rotated = f"Block_{points_slice.name}_rotated"
             insert_position_rotated = (100.0 if points_slice.slice_type == SliceType.XZ else 200.0, 0.0, 0.0)
@@ -238,6 +240,17 @@ Examples:
         help="Y position for label start (default: 0.0)"
     )
 
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.050,
+        help=(
+            "Threshold for slice-type detection (max allowed variation of the"
+            " smallest axis). Smaller means stricter; larger means more"
+            " tolerant. Default: 0.050"
+        ),
+    )
+
     args = parser.parse_args()
     
     # Validate colors if provided
@@ -251,9 +264,10 @@ Examples:
     
     create_dxf_from_csv_directory(
         args.input_directory,
-        args.output_file, 
+        args.output_file,
         args.colors,
-        label_position
+        label_position,
+        threshold=args.threshold,
     )
 
 

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -78,13 +78,18 @@ def detect_slice_type_from_data(
         return SliceType.UNKNOWN
 
 
-def parse_csv_file(filepath: str, max_points: Optional[int] = None) -> PointsSlice:
+def parse_csv_file(
+    filepath: str,
+    max_points: Optional[int] = None,
+    threshold: float = 0.050,
+) -> PointsSlice:
     """
     Parse a space-separated CSV file containing 3D point coordinates.
 
     Args:
         filepath: Path to the CSV file to parse
         max_points: Maximum number of points to read (None for all points)
+        threshold: Maximum variation allowed to consider a dimension constant
 
     Returns:
         PointsSlice object containing the parsed points and metadata
@@ -144,13 +149,15 @@ def parse_csv_file(filepath: str, max_points: Optional[int] = None) -> PointsSli
         raise ValueError(f"No valid points found in file {filepath}")
 
     # Determine metadata
-    slice_type = detect_slice_type_from_data(points)
+    slice_type = detect_slice_type_from_data(points, threshold=threshold)
 
     return PointsSlice(points=points, name=name, slice_type=slice_type)
 
 
 def parse_directory(
-    directory_path: str, max_points_per_file: Optional[int] = None
+    directory_path: str,
+    max_points_per_file: Optional[int] = None,
+    threshold: float = 0.050,
 ) -> List[PointsSlice]:
     """
     Parse all CSV files in a directory.
@@ -158,6 +165,7 @@ def parse_directory(
     Args:
         directory_path: Path to directory containing CSV files
         max_points_per_file: Maximum points to read per file (None for all)
+        threshold: Maximum variation allowed to consider a dimension constant
 
     Returns:
         List of PointsSlice objects
@@ -181,7 +189,11 @@ def parse_directory(
     for filename in csv_files:
         filepath = os.path.join(directory_path, filename)
         try:
-            slice_obj = parse_csv_file(filepath, max_points_per_file)
+            slice_obj = parse_csv_file(
+                filepath,
+                max_points=max_points_per_file,
+                threshold=threshold,
+            )
             slices.append(slice_obj)
             print(
                 f"Parsed {filename}: {len(slice_obj.points)} points, type: {slice_obj.slice_type.value}"


### PR DESCRIPTION
- Introduced a `threshold` argument in `create_dxf_from_csv_directory` and `parse_csv_file` to control slice-type detection sensitivity.
- Updated the README to document the new `--threshold` command-line option and its default value.
- Adjusted the `parse_directory` function to pass the threshold value during CSV file parsing.