### PR TITLE
Issue-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ python point_slice_studio_cli.py [input_directory] [output_file] [options]
 
 - `--colors COLOR [COLOR ...]`: Custom AutoCAD color indices (1-256)
   - Default: `1 2 3 4 5 6 7 8 9 10`
+- `--anchor-x FLOAT`: X coordinate of the imported point cloud
+  - Default: `0.0`
+- `--anchor-y FLOAT`: Y coordinate of the imported point cloud
+  - Default: `0.0`
+- `--xz-rotated-x-offset FLOAT`: X offset added to the anchor for rotated XZ slices
+  - Default: `-300.0`
+- `--yz-rotated-x-offset FLOAT`: X offset added to the anchor for rotated YZ slices
+  - Default: `-200.0`
 - `--label-x FLOAT`: X position for label start
   - Default: `-40.0`
 - `--label-y FLOAT`: Y position for label start
@@ -211,6 +219,9 @@ python point_slice_studio_cli.py --colors 1 3 5 4
 
 # Position labels at custom location
 python point_slice_studio_cli.py --label-x -100 --label-y 50
+
+# Anchor and offsets for rotated XZ/YZ blocks (defaults match the workflow)
+python point_slice_studio_cli.py path/to/csv/files output.dxf --anchor-x 0 --anchor-y 0 --xz-rotated-x-offset -300 --yz-rotated-x-offset -200
 
 # Adjust slice detection threshold (e.g., stricter)
 python point_slice_studio_cli.py path/to/csv/files output.dxf --threshold 0.005

--- a/point_slice_studio_cli.py
+++ b/point_slice_studio_cli.py
@@ -46,6 +46,7 @@ Examples:
     python point_slice_studio_cli.py                                    # Use defaults
     python point_slice_studio_cli.py data/csv_files output.dxf         # Custom paths
     python point_slice_studio_cli.py /path/to/csv/files result.dxf     # Absolute paths
+    python point_slice_studio_cli.py in/ out.dxf --anchor-x 10 --xz-rotated-x-offset -250
         """,
     )
 
@@ -68,6 +69,38 @@ Examples:
         nargs="+",
         type=int,
         help="Custom color indices (1-256) for AutoCAD colors",
+    )
+
+    parser.add_argument(
+        "--anchor-x",
+        type=float,
+        default=0.0,
+        help="X coordinate of the starting point of the imported point cloud (default: 0.0)",
+    )
+
+    parser.add_argument(
+        "--anchor-y",
+        type=float,
+        default=0.0,
+        help="Y coordinate of the starting point of the imported point cloud (default: 0.0)",
+    )
+
+    parser.add_argument(
+        "--xz-rotated-x-offset",
+        type=float,
+        default=-300.0,
+        help=(
+            "X offset added to anchor X for rotated XZ slices (default: -300.0)"
+        ),
+    )
+
+    parser.add_argument(
+        "--yz-rotated-x-offset",
+        type=float,
+        default=-200.0,
+        help=(
+            "X offset added to anchor X for rotated YZ slices (default: -200.0)"
+        ),
     )
 
     parser.add_argument(
@@ -107,12 +140,16 @@ Examples:
             return
 
     label_position = (args.label_x, args.label_y)
+    anchor_point = (args.anchor_x, args.anchor_y)
 
     create_dxf_from_csv_directory(
         args.input_directory,
         args.output_file,
-        args.colors,
-        label_position,
+        anchor_point=anchor_point,
+        xz_rotated_x_offset=args.xz_rotated_x_offset,
+        yz_rotated_x_offset=args.yz_rotated_x_offset,
+        colors=args.colors,
+        label_position=label_position,
         threshold=args.threshold,
     )
 

--- a/point_slice_studio_cli.py
+++ b/point_slice_studio_cli.py
@@ -89,18 +89,14 @@ Examples:
         "--xz-rotated-x-offset",
         type=float,
         default=-300.0,
-        help=(
-            "X offset added to anchor X for rotated XZ slices (default: -300.0)"
-        ),
+        help=("X offset added to anchor X for rotated XZ slices (default: -300.0)"),
     )
 
     parser.add_argument(
         "--yz-rotated-x-offset",
         type=float,
         default=-200.0,
-        help=(
-            "X offset added to anchor X for rotated YZ slices (default: -200.0)"
-        ),
+        help=("X offset added to anchor X for rotated YZ slices (default: -200.0)"),
     )
 
     parser.add_argument(

--- a/point_slice_studio_gui.py
+++ b/point_slice_studio_gui.py
@@ -281,11 +281,15 @@ class PointSliceStudioGUI:
         offsets_frame.pack(anchor=tk.W, fill=tk.X)
         offsets_inner = ttk.Frame(offsets_frame)
         offsets_inner.pack(anchor=tk.W)
-        ttk.Label(offsets_inner, text="XZ-slice X offset:").pack(side=tk.LEFT, padx=(0, 4))
+        ttk.Label(offsets_inner, text="XZ-slice X offset:").pack(
+            side=tk.LEFT, padx=(0, 4)
+        )
         ttk.Entry(offsets_inner, textvariable=self.xz_rotated_x_offset, width=12).pack(
             side=tk.LEFT, padx=(0, 12)
         )
-        ttk.Label(offsets_inner, text="YZ-slice X offset:").pack(side=tk.LEFT, padx=(0, 4))
+        ttk.Label(offsets_inner, text="YZ-slice X offset:").pack(
+            side=tk.LEFT, padx=(0, 4)
+        )
         ttk.Entry(offsets_inner, textvariable=self.yz_rotated_x_offset, width=12).pack(
             side=tk.LEFT
         )

--- a/point_slice_studio_gui.py
+++ b/point_slice_studio_gui.py
@@ -132,6 +132,10 @@ class PointSliceStudioGUI:
         self.colors_text = tk.StringVar(value="1 2 3 4 5 6 7 8 9 10")
         self.label_x = tk.DoubleVar(value=-40.0)
         self.label_y = tk.DoubleVar(value=0.0)
+        self.anchor_x = tk.DoubleVar(value=0.0)
+        self.anchor_y = tk.DoubleVar(value=0.0)
+        self.xz_rotated_x_offset = tk.DoubleVar(value=-300.0)
+        self.yz_rotated_x_offset = tk.DoubleVar(value=-200.0)
 
         self.processing = False
 
@@ -247,6 +251,53 @@ class PointSliceStudioGUI:
         ttk.Label(label_inner, text="Y:").pack(side=tk.LEFT, padx=(0, 2))
         self.label_y_entry = ttk.Entry(label_inner, textvariable=self.label_y, width=12)
         self.label_y_entry.pack(side=tk.LEFT)
+
+        row += 1
+
+        # Anchor point and rotated-slice offsets (separate groups)
+        layout_wrapper = ttk.Frame(main_frame)
+        layout_wrapper.grid(row=row, column=0, columnspan=3, sticky=tk.W, pady=10)
+
+        anchor_frame = ttk.LabelFrame(layout_wrapper, text="Anchor point", padding="5")
+        anchor_frame.pack(anchor=tk.W, fill=tk.X, pady=(0, 8))
+        anchor_inner = ttk.Frame(anchor_frame)
+        anchor_inner.pack(anchor=tk.W)
+        ttk.Label(anchor_inner, text="X:").pack(side=tk.LEFT, padx=(0, 2))
+        ttk.Entry(anchor_inner, textvariable=self.anchor_x, width=12).pack(
+            side=tk.LEFT, padx=(0, 12)
+        )
+        ttk.Label(anchor_inner, text="Y:").pack(side=tk.LEFT, padx=(0, 2))
+        ttk.Entry(anchor_inner, textvariable=self.anchor_y, width=12).pack(side=tk.LEFT)
+        ttk.Label(
+            anchor_frame,
+            text="Base (x, y) of the imported point cloud (CLI: --anchor-x / --anchor-y).",
+            font=("TkDefaultFont", 8),
+            foreground="gray",
+        ).pack(anchor=tk.W, pady=(6, 0))
+
+        offsets_frame = ttk.LabelFrame(
+            layout_wrapper, text="Rotated slice offsets", padding="5"
+        )
+        offsets_frame.pack(anchor=tk.W, fill=tk.X)
+        offsets_inner = ttk.Frame(offsets_frame)
+        offsets_inner.pack(anchor=tk.W)
+        ttk.Label(offsets_inner, text="XZ-slice X offset:").pack(side=tk.LEFT, padx=(0, 4))
+        ttk.Entry(offsets_inner, textvariable=self.xz_rotated_x_offset, width=12).pack(
+            side=tk.LEFT, padx=(0, 12)
+        )
+        ttk.Label(offsets_inner, text="YZ-slice X offset:").pack(side=tk.LEFT, padx=(0, 4))
+        ttk.Entry(offsets_inner, textvariable=self.yz_rotated_x_offset, width=12).pack(
+            side=tk.LEFT
+        )
+        ttk.Label(
+            offsets_frame,
+            text=(
+                "Added to anchor X for each rotated slice type "
+                "(CLI: --xz-rotated-x-offset / --yz-rotated-x-offset)."
+            ),
+            font=("TkDefaultFont", 8),
+            foreground="gray",
+        ).pack(anchor=tk.W, pady=(6, 0))
 
         row += 1
 
@@ -397,6 +448,9 @@ class PointSliceStudioGUI:
         output_file = self.output_file.get()
         colors = self.parse_colors()
         label_position = (self.label_x.get(), self.label_y.get())
+        anchor_point = (self.anchor_x.get(), self.anchor_y.get())
+        xz_off = self.xz_rotated_x_offset.get()
+        yz_off = self.yz_rotated_x_offset.get()
 
         self._redirector = RedirectText(self.log_text)
         self._redirector.start_polling()
@@ -406,12 +460,29 @@ class PointSliceStudioGUI:
 
         thread = threading.Thread(
             target=self._run_processing,
-            args=(input_dir, output_file, colors, label_position),
+            args=(
+                input_dir,
+                output_file,
+                colors,
+                label_position,
+                anchor_point,
+                xz_off,
+                yz_off,
+            ),
             daemon=True,
         )
         thread.start()
 
-    def _run_processing(self, input_dir, output_file, colors, label_position):
+    def _run_processing(
+        self,
+        input_dir,
+        output_file,
+        colors,
+        label_position,
+        anchor_point,
+        xz_rotated_x_offset,
+        yz_rotated_x_offset,
+    ):
         """Run the actual processing in a background thread.
 
         This method only calls ``create_dxf_from_csv_directory`` (which
@@ -422,8 +493,11 @@ class PointSliceStudioGUI:
             create_dxf_from_csv_directory(
                 input_dir,
                 output_file,
-                colors,
-                label_position,
+                anchor_point=anchor_point,
+                xz_rotated_x_offset=xz_rotated_x_offset,
+                yz_rotated_x_offset=yz_rotated_x_offset,
+                colors=colors,
+                label_position=label_position,
             )
 
             self.root.after(

--- a/src/ps_core/workflow.py
+++ b/src/ps_core/workflow.py
@@ -32,8 +32,11 @@ from ps_core.points_slice import SliceType, rotate_slice_to_xy
 def create_dxf_from_csv_directory(
     input_directory: str,
     output_file: str,
-    colors: List[int] = None,
-    label_position: tuple[float, float] = None,
+    anchor_point: tuple[float, float] = (0.0, 0.0),
+    xz_rotated_x_offset: float = -300.0,
+    yz_rotated_x_offset: float = -200.0,
+    colors: List[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    label_position: tuple[float, float] = (-40.0, 0.0),
     threshold: float = 0.050,
 ) -> None:
     """
@@ -42,6 +45,9 @@ def create_dxf_from_csv_directory(
     Args:
         input_directory: Directory containing CSV files
         output_file: Output DXF filename
+        anchor_point: (x, y) base for placing rotated XZ/YZ blocks
+        xz_rotated_x_offset: Added to anchor x for rotated XZ slices
+        yz_rotated_x_offset: Added to anchor x for rotated YZ slices
         colors: List of AutoCAD color indices to use
         label_position: Starting position for labels
         threshold: Threshold for slice-type detection
@@ -78,12 +84,6 @@ def create_dxf_from_csv_directory(
         f"✅ Successfully parsed {len(points_slices)} CSV files in {parsing_duration:.3f} seconds"
     )
 
-    default_colors = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    default_label_position = (-40.0, 0.0)
-
-    colors = colors or default_colors
-    label_position = label_position or default_label_position
-
     doc = DXFDocument(colors=colors, label_start_position=label_position)
     print(f"📋 Created initial DXFDocument")
     print(f"🏷️  Label start position: {label_position}")
@@ -98,8 +98,13 @@ def create_dxf_from_csv_directory(
             points_slice_rotated = rotate_slice_to_xy(points_slice)
             block_name_rotated = f"Block_{points_slice.name}_rotated"
             insert_position_rotated = (
-                100.0 if points_slice.slice_type == SliceType.XZ else 200.0,
-                0.0,
+                anchor_point[0]
+                + (
+                    xz_rotated_x_offset
+                    if points_slice.slice_type == SliceType.XZ
+                    else yz_rotated_x_offset
+                ),
+                anchor_point[1],
                 0.0,
             )
             block_rotated = Block(


### PR DESCRIPTION
Enhance PointSliceStudioCLI and PointSliceStudioGUI with anchor point and offset options for rotated slices

- Added `--anchor-x` and `--anchor-y` arguments to CLI for specifying the base point of the imported point cloud.
- Introduced `--xz-rotated-x-offset` and `--yz-rotated-x-offset` options to adjust offsets for rotated slices in CLI.
- Updated PointSliceStudioGUI to include input fields for anchor point coordinates and rotated slice offsets.
- Modified `create_dxf_from_csv_directory` to accept new parameters for anchor point and offsets, ensuring proper placement of rotated slices.
- Updated README to document new command-line options and their defaults.